### PR TITLE
add support for new Mandrill option 'merge_language'

### DIFF
--- a/src/SlmMail/Mail/Message/Mandrill.php
+++ b/src/SlmMail/Mail/Message/Mandrill.php
@@ -61,6 +61,7 @@ class Mandrill extends Message
         'important',
         'inline_css',
         'merge',
+        'merge_language',
         'metadata',
         'preserve_recipients',
         'return_path_domain',


### PR DESCRIPTION
Recently, Mandrill added support for Handlebars based templates and with that an API option 'merge_language' (who's value can be 'handlebars' or 'mailchimp', AFAIK). 

This tiny PR adds support for this option. Tests are passing and I've manually ensured Mandrill accepts this keyword. 