### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.3
   - 5.4
 
 before_script:


### PR DESCRIPTION
ZendMail use short array syntax.
https://github.com/zendframework/zend-mail/blob/master/src/Header/HeaderValue.php#L90

As of PHP 5.4 you can also use the short array syntax, which replaces array() with [].
http://php.net/manual/en/language.types.array.php#language.types.array.syntax.array-func